### PR TITLE
Update to daos major version 1, for libdaos API update

### DIFF
--- a/mpifileutils.spec
+++ b/mpifileutils.spec
@@ -1,3 +1,4 @@
+%global daos_major 1
 %global with_mpich 1
 %global with_openmpi 0
 %global with_openmpi3 1
@@ -43,7 +44,7 @@
 
 Name:		mpifileutils
 Version:	0.10.1
-Release:	5%{?relval}%{?dist}
+Release:	6%{?relval}%{?dist}
 Summary:	File utilities designed for scalability and performance.
 
 Group:		System Environment/Libraries
@@ -75,7 +76,7 @@ Summary:	File utilities designed for scalability and performance.
 BuildRequires: openmpi3-devel
 BuildRequires: dtcmp-openmpi3-devel
 BuildRequires: libcircle-openmpi3-devel
-Provides: %{name}-openmpi3-daos-0
+Provides: %{name}-openmpi3-daos-%{daos_major}
 
 %description openmpi3
 File utilities designed for scalability and performance.
@@ -106,7 +107,7 @@ Summary:	File utilities designed for scalability and performance.
 BuildRequires: mpich-devel
 BuildRequires: dtcmp-mpich-devel
 BuildRequires: libcircle-mpich-devel
-Provides: %{name}-mpich-daos-0
+Provides: %{name}-mpich-daos-%{daos_major}
 
 %description mpich
 File utilities designed for scalability and performance.
@@ -197,6 +198,9 @@ done
 %endif
 
 %changelog
+* Mon Jan 11 2021 Kenneth Cain <kenneth.c.cain@intel.com> - 0.10.1-6
+- update to daos major version 1 for libdaos API update
+
 * Sat Dec 19 2020 Dalton A. Bohning <daltonx.bohning@intel.com> - 0.10.1-5
 - Update to 1ed76ea, now that daos is ready
 

--- a/mpifileutils.spec
+++ b/mpifileutils.spec
@@ -198,7 +198,7 @@ done
 %endif
 
 %changelog
-* Mon Jan 11 2021 Kenneth Cain <kenneth.c.cain@intel.com> - 0.10.1-6
+* Wed Jan 20 2021 Kenneth Cain <kenneth.c.cain@intel.com> - 0.10.1-6
 - update to daos major version 1 for libdaos API update
 
 * Sat Dec 19 2020 Dalton A. Bohning <daltonx.bohning@intel.com> - 0.10.1-5

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -6,6 +6,13 @@ set -uex
 IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 
 if [ -w /etc/mock/"$CHROOT_NAME".cfg ]; then
+    # Remove the distro repos
+    if [[ $CHROOT_NAME =~ opensuse-leap-* ]]; then
+        ed /etc/mock/"$CHROOT_NAME".cfg << EOF
+/^# repos$/+2;/^"""$/-1d
+wq
+EOF
+    fi
     echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/"$CHROOT_NAME".cfg
     for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
         branch="master"


### PR DESCRIPTION
And update daos_major definition in spec file to update the "virtual"
Provides (e.g., mpifileutils-mpich-daos-1 instead of
mpifileutils-mpich-daos-0).

PR-repos: daos@PR-3935:53 mpich@PR-44

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>